### PR TITLE
33 prevent parallel builds in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,15 @@
 name: Github Pages Astro CI
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
   push:
     branches: [ main ]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
+  pull_request:
   
-# Allow this job to clone the repo and create a page deployment
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write
@@ -18,18 +19,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout your repository using git
-        uses: actions/checkout@v2
-      - name: Install, build, and upload your site
-        uses: withastro/action@v0
+      - uses: actions/checkout@v3
+      - uses: withastro/action@v0
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
+      - name: 📢 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
- Fix double <header> and meta (#36)
- Prevent double deployments, and add check on PR before merge
