### PR TITLE
Normalize using sovereign links

### DIFF
--- a/src/content/social/index.json
+++ b/src/content/social/index.json
@@ -1,13 +1,13 @@
 [
   { "name": "twitter", "href": "https://twitter.com/dyneorg" },
-  { "name": "telegram", "href": "https://t.me/dyne_chat" },
+  { "name": "telegram", "href": "https://socials.dyne.org/telegram" },
   { "name": "github", "href": "https://github.com/dyne" },
   { "name": "linkedin", "href": "https://www.linkedin.com/company/dyne-org/" },
   { "name": "instagram", "href": "https://instagram.com/dyneorg" },
   { "name": "facebook", "href": "https://fb.com/dyneorg" },
   { "name": "youtube", "href": "https://www.youtube.com/DyneOrg" },
   { "name": "mastodon", "href": "https://toot.community/@dyne" },
-  { "name": "medium", "href": "https://medium.com/think-do-tank"},
-  { "name": "discord", "href": "https://discord.gg/be6Xq2zkgX" },
-  { "name": "matrix", "href": "https://matrix.to/#/#dyne:matrix.org"}
+  { "name": "medium", "href": "https://medium.com/think-do-tank" },
+  { "name": "discord", "href": "https://socials.dyne.org/discord" },
+  { "name": "matrix", "href": "https://socials.dyne.org/matrix" }
 ]


### PR DESCRIPTION
Some platforms are at risk of getting their URL swapped out. In order to never have broken links and preserve
promotional work, we can leverage trecarte