### PR TITLE
Replace Telegram with GitHub in quicklinks

### DIFF
--- a/src/content/social/quicklinks.json
+++ b/src/content/social/quicklinks.json
@@ -1,7 +1,7 @@
 [
   {
-    "link": "https://socials.dyne.org/telegram",
-    "cta": "Telegram"
+    "link": "https://socials.dyne.org/github",
+    "cta": "Github"
   },
   {
     "link": "https://socials.dyne.org/discord",

--- a/src/content/social/quicklinks.json
+++ b/src/content/social/quicklinks.json
@@ -1,7 +1,7 @@
 [
   {
     "link": "https://socials.dyne.org/github",
-    "cta": "Github"
+    "cta": "GitHub"
   },
   {
     "link": "https://socials.dyne.org/discord",


### PR DESCRIPTION
There was an ambition to progressively move away from telegram, and since all three of those are bridged anyways, i think it makes sense to have GitHub as a quicklink. This being one of the prime methods of communication for devs.