### PR TITLE
Replace discord with newsletter in the dive in section

### DIFF
--- a/src/content/social/quicklinks.json
+++ b/src/content/social/quicklinks.json
@@ -4,8 +4,8 @@
     "cta": "GitHub"
   },
   {
-    "link": "https://socials.dyne.org/discord",
-    "cta": "Discord"
+    "link": "https://news.dyne.org",
+    "cta": "Newsletter"
   },
   {
     "link": "https://socials.dyne.org/matrix",


### PR DESCRIPTION
Currently there are 3 links in the dive in section:

- Github
- Discord
- Matrix

Matrix is hard but fits the ethos better. Discord links are available lower on the page anyways. Two chats is redundant, and we really want quick access to the newsletter. So i am proposing this change.